### PR TITLE
Patching for CVE-2019-5477

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
     mustermann (1.0.3)
     netaddr (1.5.1)
     nio4r (2.4.0)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     nori (2.6.0)
     parallel (1.17.0)


### PR DESCRIPTION
Ran `bundle update --patch --conservative nokogiri`.

Name: nokogiri
Version: 1.10.3
Advisory: CVE-2019-5477
Criticality: High
URL: https://github.com/sparklemotion/nokogiri/issues/1915
Title: Nokogiri Command Injection Vulnerability via Nokogiri::CSS::Tokenizer#load_file
Solution: upgrade to >= 1.10.4